### PR TITLE
Update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vueform/multiselect",
-  "version": "2.5.7",
+  "version": "2.6.0",
   "private": false,
   "description": "Vue 3 multiselect component with single select, multiselect and tagging options.",
   "license": "MIT",


### PR DESCRIPTION
Since this version contains breaking changes, I feel like it should be versioned above 2.5, for people who have it as ^2.5.X in their package.json. This versioning caused problems, and forced me to lock the old 2.5.6 version manually.